### PR TITLE
Add a fixed frequency schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ else the next execution will likely be skipped (depending of the `Schedule` impl
 
 ### Basics schedules
 Basics schedules are referenced in the `Schedules` class:
-- `fixedDelaySchedule(Duration)`: execute a job at a fixed delay after each execution
+- `fixedDelaySchedule(Duration)`: execute a job at a fixed delay after each execution. The delay is not guaranteed to be consistent depending on system load
+- `fixedFrequencySchedule(Duration)`: execute a job at a fixed frequency independent of the time the method was called and the system load (like cron)
 - `executeAt(String)`: execute a job at the same time every day, e.g. `executeAt("05:30")`
 
 ### Composition

--- a/src/main/java/com/coreoz/wisp/schedule/FixedDelaySchedule.java
+++ b/src/main/java/com/coreoz/wisp/schedule/FixedDelaySchedule.java
@@ -12,7 +12,7 @@ public class FixedDelaySchedule implements Schedule {
 
 	@Override
 	public long nextExecutionInMillis(long currentTimeInMillis, int executionsCount, Long lastExecutionTimeInMillis) {
-		return currentTimeInMillis + frequency.toMillis();
+		return currentTimeInMillis + frequency.toMillis() - (currentTimeInMillis % frequency.toMillis());
 	}
 
 	@Override

--- a/src/main/java/com/coreoz/wisp/schedule/FixedDelaySchedule.java
+++ b/src/main/java/com/coreoz/wisp/schedule/FixedDelaySchedule.java
@@ -12,7 +12,7 @@ public class FixedDelaySchedule implements Schedule {
 
 	@Override
 	public long nextExecutionInMillis(long currentTimeInMillis, int executionsCount, Long lastExecutionTimeInMillis) {
-		return currentTimeInMillis + frequency.toMillis() - (currentTimeInMillis % frequency.toMillis());
+		return currentTimeInMillis + frequency.toMillis();
 	}
 
 	@Override

--- a/src/main/java/com/coreoz/wisp/schedule/FixedFrequencySchedule.java
+++ b/src/main/java/com/coreoz/wisp/schedule/FixedFrequencySchedule.java
@@ -1,0 +1,22 @@
+package com.coreoz.wisp.schedule;
+
+import java.time.Duration;
+
+public class FixedFrequencySchedule implements Schedule {
+
+	private final Duration frequency;
+
+	public FixedFrequencySchedule(Duration frequency) {
+		this.frequency = frequency;
+	}
+
+	@Override
+	public long nextExecutionInMillis(long currentTimeInMillis, int executionsCount, Long lastExecutionEndedTimeInMillis) {
+		return currentTimeInMillis + frequency.toMillis() - (currentTimeInMillis % frequency.toMillis());
+	}
+
+	@Override
+	public String toString() {
+		return "every " + frequency.toMillis() + "ms";
+	}
+}

--- a/src/main/java/com/coreoz/wisp/schedule/Schedules.java
+++ b/src/main/java/com/coreoz/wisp/schedule/Schedules.java
@@ -15,6 +15,13 @@ public class Schedules {
 	}
 
 	/**
+	 * Execute a job at a fixed frequency which is guaranteed to be within 1ms of accuracy independent of system load
+	 */
+	public static Schedule fixedFrequencySchedule(Duration duration) {
+		return new FixedFrequencySchedule(duration);
+	}
+
+	/**
 	 * Execute a job at the same time once a day.
 	 * The time format must be "hh:mm" or "hh:mm:ss"
 	 */

--- a/src/test/java/com/coreoz/wisp/schedule/FixedFrequencyScheduleTest.java
+++ b/src/test/java/com/coreoz/wisp/schedule/FixedFrequencyScheduleTest.java
@@ -1,0 +1,25 @@
+package com.coreoz.wisp.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class FixedFrequencyScheduleTest {
+
+	@Test
+	public void test_next_execution_rounded() {
+		assertThat(Schedules.fixedFrequencySchedule(Duration.ofHours(2))
+				.nextExecutionInMillis(8000, 0, 0L))
+				.isEqualTo(TimeUnit.HOURS.toMillis(2));
+	}
+
+	@Test
+	public void test_next_execution_too_much() {
+		assertThat(Schedules.fixedFrequencySchedule(Duration.ofHours(2))
+				.nextExecutionInMillis(TimeUnit.HOURS.toMillis(3), 0, 0L))
+				.isEqualTo(TimeUnit.HOURS.toMillis(4));
+	}
+}


### PR DESCRIPTION
When just adding the frequency to the current time, due to the system load the execution time will shift by a few milliseconds every run. So after a few hundred runs the delay will no longer be f.ex. 5 minutes but 5 minutes and 10 seconds. This is now fixed by always calculating the time remaining