### PR TITLE
Add JPMS Compatibility (Java 9+)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,17 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.coreoz.wisp</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This is required because otherwise it is **impossible** to use this library in a modularized java project. Another option would be to bump the minimum java version to 9 and create a `module-info.class` file

EDIT: other way would be a multi release jar following this guide: https://www.baeldung.com/java-multi-release-jar

EDIT2: The automatic module name should never **ever** be changed after 2.6.0 release because it would be a breaking change